### PR TITLE
No more stratum connection interruption.

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1406,7 +1406,7 @@ static void *stratum_thread(void *userdata) {
             }
         }
 
-        if (!stratum_socket_full(&stratum, 120)) {
+        if (!stratum_socket_full(&stratum, 300)) {
             applog(LOG_ERR, "Stratum connection timed out");
             s = NULL;
         } else


### PR DESCRIPTION
Increased timeout to 5 minutes to get rid of disconnects if there are no blocks in a network for 2 minutes.
Clean way to handle this issue instead of cheating on pool side with stupid job retransmission.